### PR TITLE
Added the black and ruby version of the theme.

### DIFF
--- a/themes/bearded.json
+++ b/themes/bearded.json
@@ -1057,6 +1057,217 @@
           }
         }
       }
+    },
+    {
+      "name": "Bearded Theme Black & Ruby",
+      "appearance": "dark",
+      "style": {
+        "border": "#040506",
+        "border.variant": "#0c0f11",
+        "border.focused": "#3b4654",
+        "border.selected": "#3b4654",
+        "border.transparent": "#00000000",
+        "border.disabled": "#040506",
+        "elevated_surface.background": "#1c2027",
+        "surface.background": "#111418",
+        "background": "#111418",
+        "element.background": "#262d36",
+        "element.hover": "#262d36",
+        "element.active": "#262d36",
+        "element.selected": "#31384573",
+        "element.disabled": "#1c2027",
+        "drop_target.background": "#c62f5215",
+        "ghost_element.background": "#00000000",
+        "ghost_element.hover": "#272c3633",
+        "ghost_element.active": "#262d36",
+        "ghost_element.selected": "#262d36",
+        "ghost_element.disabled": "#1c2027",
+        "text": "#bec6d0",
+        "text.muted": "#a0acbb",
+        "text.placeholder": "#475262",
+        "text.disabled": "#475262",
+        "text.accent": "#c62f52",
+        "icon": "#a0acbb",
+        "icon.muted": "#475262",
+        "icon.disabled": "#475262",
+        "icon.placeholder": "#475262",
+        "icon.accent": "#c62f52",
+        "status_bar.background": "#111418",
+        "title_bar.background": "#080a0c",
+        "toolbar.background": "#131313",
+        "tab_bar.background": "#0c0f11",
+        "tab.inactive_background": "#0c0f11",
+        "tab.active_background": "#111418",
+        "search.match_background": "#c62f5240",
+        "panel.background": "#0f1215",
+        "panel.focused_border": "#262d36",
+        "pane.focused_border": "#262d36",
+        "scrollbar.thumb.background": "#bec6d026",
+        "scrollbar.thumb.hover_background": "#bec6d033",
+        "scrollbar.thumb.border": "#bec6d026",
+        "scrollbar.track.background": "#00000000",
+        "scrollbar.track.border": "#040506",
+        "editor.foreground": "#bec6d0",
+        "editor.background": "#111418",
+        "editor.gutter.background": "#111418",
+        "editor.subheader.background": "#1c2027",
+        "editor.active_line.background": "#c62f520f",
+        "editor.highlighted_line.background": "#272c3633",
+        "editor.line_number": "#343a43",
+        "editor.active_line_number": "#85929e",
+        "editor.invisible": "#47526260",
+        "editor.wrap_guide": "#252e3f",
+        "editor.active_wrap_guide": "#252e3f",
+        "editor.document_highlight.read_background": "#262d36",
+        "editor.document_highlight.write_background": "#262d36",
+        "terminal.background": "#0f1215",
+        "terminal.foreground": "#bec6d0",
+        "terminal.bright_foreground": "#bec6d0",
+        "terminal.dim_foreground": "#475262",
+        "terminal.ansi.black": "#111418",
+        "terminal.ansi.bright_black": "#3a4551",
+        "terminal.ansi.red": "#E35535",
+        "terminal.ansi.bright_red": "#ff4319",
+        "terminal.ansi.green": "#00a884",
+        "terminal.ansi.bright_green": "#00a884",
+        "terminal.ansi.yellow": "#c7910c",
+        "terminal.ansi.bright_yellow": "#d39600",
+        "terminal.ansi.blue": "#11B7D4",
+        "terminal.ansi.bright_blue": "#00c3e5",
+        "terminal.ansi.magenta": "#d46ec0",
+        "terminal.ansi.bright_magenta": "#f052d1",
+        "terminal.ansi.cyan": "#38c7bd",
+        "terminal.ansi.bright_cyan": "#12edde",
+        "terminal.ansi.white": "#bec6d0",
+        "terminal.ansi.bright_white": "#f9fafb",
+        "link_text.hover": "#11B7D4",
+        "conflict": "#c7910c",
+        "conflict.background": "#1c2027",
+        "conflict.border": "#c7910c", 
+        "created": "#00a884",
+        "created.background": "#1c2027",
+        "created.border": "#00a884",
+        "deleted": "#E35535",
+        "deleted.background": "#1c2027",
+        "deleted.border": "#E35535",
+        "error": "#E35535",
+        "error.background": "#1c2027",
+        "error.border": "#E35535",
+        "hint": "#a0acbb",
+        "hint.background": "#1c2027",
+        "hint.border": "#a0acbb",
+        "ignored": "#475262",
+        "ignored.background": "#1c2027",
+        "ignored.border": "#475262",
+        "info": "#11B7D4",
+        "info.background": "#1c2027",
+        "info.border": "#11B7D4",
+        "modified": "#c7910c",
+        "modified.background": "#1c2027",
+        "modified.border": "#c7910c",
+        "warning": "#d4770c",
+        "warning.background": "#1c2027",
+        "warning.border": "#d4770c",
+        "players": [
+          {
+            "cursor": "#c7910c",
+            "background": "#c7910c",
+            "selection": "#c62f524d"
+          }
+        ],
+        "syntax": {
+          "attribute": {
+            "color": "#d4770c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "boolean": {
+            "color": "#E35535",
+            "font_style": null,
+            "font_weight": null
+          },
+          "comment": {
+            "color": "#b6c5d859",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "comment.doc": {
+            "color": "#b6c5d859",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "constructor": {
+            "color": "#a85ff1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "function": {
+            "color": "#11B7D4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "keyword": {
+            "color": "#c7910c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#d4770c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "number": {
+            "color": "#d4770c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "operator": {
+            "color": "#c7910c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "parameter": {
+            "color": "#d46ec0",
+            "font_style": null,
+            "font_weight": null
+          },
+          "property": {
+            "color": "#d4770c",
+            "font_style": null,
+            "font_weight": null
+          },
+          "punctuation": {
+            "color": "#bec6d060",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string": {
+            "color": "#00a884",
+            "font_style": null,
+            "font_weight": null
+          },
+          "string.escape": {
+            "color": "#38c7bd",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag": {
+            "color": "#11B7D4",
+            "font_style": null,
+            "font_weight": null
+          },
+          "type": {
+            "color": "#a85ff1",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable": {
+            "color": "#c62f52",
+            "font_style": null,
+            "font_weight": null
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
I have added the Black and Ruby version of the theme. However, I was unable to verify its accuracy. I attempted to test it by placing the updated JSON file in the Zed themes folder, but I couldn’t find the Black and Ruby option in the list. I apologize for any inconvenience this may cause, and I would greatly appreciate it if you could verify that it works correctly.